### PR TITLE
Release 0.0.34 [ci:run]

### DIFF
--- a/charts/neo4jv2025/Chart.yaml
+++ b/charts/neo4jv2025/Chart.yaml
@@ -15,16 +15,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.35
+version: 0.0.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2025.10.1"
+appVersion: "2025.12.1"
 dependencies:
   - name: neo4j
-    version: 2025.10.1-4
+    version: 2025.12.1
     repository: https://helm.neo4j.com/neo4j
 maintainers:
   - name: enys

--- a/charts/neo4jv2025/values.preview.yaml
+++ b/charts/neo4jv2025/values.preview.yaml
@@ -3,6 +3,6 @@ neo4j:
   config:
     # Devops, Engineering
     dbms.security.oidc.azure.authorization.group_to_role_mapping: |
-      "898f17fd-e481-4f80-a578-8d25b0774206" = admin; \
-      "d41f1b69-a7dd-47fb-a1f6-977031b1971f" = admin;
+      "85e901b9-1ac4-4cae-9f3c-a0a0840f5491" = admin; \
+      "fc44e40f-bbe4-4d23-a0b7-2b543cc61240" = admin;
 

--- a/charts/neo4jv2025/values.prod.yaml
+++ b/charts/neo4jv2025/values.prod.yaml
@@ -34,10 +34,10 @@ neo4j:
     edition: "enterprise"
     acceptLicenseAgreement: "yes"
   config:
-    dbms.security.oidc.azure.audience: 0d51e3f5-5053-4d39-81f2-a49ba2978e69
-    dbms.security.oidc.azure.params: "client_id=0d51e3f5-5053-4d39-81f2-a49ba2978e69;response_type=code;scope=openid profile email"
+    dbms.security.oidc.azure.audience: 48fb6eca-ced1-486a-8399-6230963be242
+    dbms.security.oidc.azure.params: "client_id=48fb6eca-ced1-486a-8399-6230963be242;response_type=code;scope=openid profile email"
     dbms.security.oidc.azure.authorization.group_to_role_mapping: |
-      "898f17fd-e481-4f80-a578-8d25b0774206" = admin;
+      "85e901b9-1ac4-4cae-9f3c-a0a0840f5491" = admin;
 
     # used to workaround lack of config in helm chart
     DATASETS_JSON: |-

--- a/charts/neo4jv2025/values.saas-trials.yaml
+++ b/charts/neo4jv2025/values.saas-trials.yaml
@@ -34,10 +34,10 @@ neo4j:
     edition: "enterprise"
     acceptLicenseAgreement: "yes"
   config:
-    dbms.security.oidc.azure.audience: 0d51e3f5-5053-4d39-81f2-a49ba2978e69
-    dbms.security.oidc.azure.params: "client_id=0d51e3f5-5053-4d39-81f2-a49ba2978e69;response_type=code;scope=openid profile email"
+    dbms.security.oidc.azure.audience: 48fb6eca-ced1-486a-8399-6230963be242
+    dbms.security.oidc.azure.params: "client_id=48fb6eca-ced1-486a-8399-6230963be242;response_type=code;scope=openid profile email"
     dbms.security.oidc.azure.authorization.group_to_role_mapping: |
-      "898f17fd-e481-4f80-a578-8d25b0774206" = admin;
+      "85e901b9-1ac4-4cae-9f3c-a0a0840f5491" = admin;
 
     # used to workaround lack of config in helm chart
     DATASETS_JSON: |-

--- a/charts/neo4jv2025/values.yaml
+++ b/charts/neo4jv2025/values.yaml
@@ -42,16 +42,16 @@ neo4j:
     dbms.security.authorization_providers: oidc-azure,native
     dbms.security.oidc.azure.display_name: Azure
     dbms.security.oidc.azure.auth_flow: pkce
-    dbms.security.oidc.azure.well_known_discovery_uri: https://login.microsoftonline.com/9c0acfe4-4dba-44f4-b8ae-c39d9aa8d991/v2.0/.well-known/openid-configuration
-    dbms.security.oidc.azure.audience: 53d9ec2c-b8dd-4e1e-96a2-b9c484205353
+    dbms.security.oidc.azure.well_known_discovery_uri: https://login.microsoftonline.com/a00035bc-d628-4788-97c4-bbfbf70f3e7a/v2.0/.well-known/openid-configuration
+    dbms.security.oidc.azure.audience: 163f10a2-9e7c-4ed4-859d-94cba9851ffc
     dbms.security.oidc.azure.claims.username: email
     dbms.security.oidc.azure.claims.groups: groups
-    dbms.security.oidc.azure.params: "client_id=53d9ec2c-b8dd-4e1e-96a2-b9c484205353;response_type=code;scope=openid profile email"
+    dbms.security.oidc.azure.params: "client_id=163f10a2-9e7c-4ed4-859d-94cba9851ffc;response_type=code;scope=openid profile email"
     dbms.security.oidc.azure.config: "token_type_principal=id_token;token_type_authentication=id_token"
     # Devops, Lke Team
     dbms.security.oidc.azure.authorization.group_to_role_mapping: |
-      "898f17fd-e481-4f80-a578-8d25b0774206" = admin; \
-      "644873fa-c49b-416b-800f-c40b55ccca9e" = reader
+      "85e901b9-1ac4-4cae-9f3c-a0a0840f5491" = admin; \
+      "57d6f475-4a6c-45e1-a260-4692dc1e5d08" = reader
     dbms.security.procedures.unrestricted: 'gds.*,apoc.*'
     server.metrics.prometheus.enabled: 'true'
     server.metrics.prometheus.endpoint: '0.0.0.0:2004'

--- a/charts/neo4jv5/Chart.yaml
+++ b/charts/neo4jv5/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.36
+version: 0.0.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,7 +24,7 @@ version: 0.0.36
 appVersion: "5.26.8"
 dependencies:
   - name: neo4j
-    version: 5.26.24
+    version: 5.26.28
     repository: https://helm.neo4j.com/neo4j
 maintainers:
   - name: enys

--- a/charts/neo4jv5/values.preview.yaml
+++ b/charts/neo4jv5/values.preview.yaml
@@ -3,6 +3,6 @@ neo4j:
   config:
     # Devops, Engineering
     dbms.security.oidc.azure.authorization.group_to_role_mapping: |
-      "898f17fd-e481-4f80-a578-8d25b0774206" = admin; \
-      "d41f1b69-a7dd-47fb-a1f6-977031b1971f" = admin;
+      "85e901b9-1ac4-4cae-9f3c-a0a0840f5491" = admin; \
+      "fc44e40f-bbe4-4d23-a0b7-2b543cc61240" = admin;
 

--- a/charts/neo4jv5/values.yaml
+++ b/charts/neo4jv5/values.yaml
@@ -42,16 +42,16 @@ neo4j:
     dbms.security.authorization_providers: oidc-azure,native
     dbms.security.oidc.azure.display_name: Azure
     dbms.security.oidc.azure.auth_flow: pkce
-    dbms.security.oidc.azure.well_known_discovery_uri: https://login.microsoftonline.com/9c0acfe4-4dba-44f4-b8ae-c39d9aa8d991/v2.0/.well-known/openid-configuration
-    dbms.security.oidc.azure.audience: 53d9ec2c-b8dd-4e1e-96a2-b9c484205353
+    dbms.security.oidc.azure.well_known_discovery_uri: https://login.microsoftonline.com/a00035bc-d628-4788-97c4-bbfbf70f3e7a/v2.0/.well-known/openid-configuration
+    dbms.security.oidc.azure.audience: 163f10a2-9e7c-4ed4-859d-94cba9851ffc
     dbms.security.oidc.azure.claims.username: email
     dbms.security.oidc.azure.claims.groups: groups
-    dbms.security.oidc.azure.params: "client_id=53d9ec2c-b8dd-4e1e-96a2-b9c484205353;response_type=code;scope=openid profile email"
+    dbms.security.oidc.azure.params: "client_id=163f10a2-9e7c-4ed4-859d-94cba9851ffc;response_type=code;scope=openid profile email"
     dbms.security.oidc.azure.config: "token_type_principal=id_token;token_type_authentication=id_token"
     # Devops, Lke Team
     dbms.security.oidc.azure.authorization.group_to_role_mapping: |
-      "898f17fd-e481-4f80-a578-8d25b0774206" = admin; \
-      "644873fa-c49b-416b-800f-c40b55ccca9e" = reader
+      "85e901b9-1ac4-4cae-9f3c-a0a0840f5491" = admin; \
+      "57d6f475-4a6c-45e1-a260-4692dc1e5d08" = reader
     dbms.security.procedures.unrestricted: 'gds.*,apoc.*'
     metrics.prometheus.enabled: 'true'
     server.metrics.prometheus.enabled: 'true'


### PR DESCRIPTION
- **Update Helm release neo4j to v5.26.28 charts/neo4jv5- (#196)**
- **Update Helm release neo4j to v2025.12.1 charts/neo4jv2025- (#197)**
- **OPS-2818: Switch to nuix entra fo neo4j preprod (#195)**
- **OPS-2818: Prod and saas Nuix entra Auth (#199)**
